### PR TITLE
Always publish parameter.

### DIFF
--- a/include/flir_spinnaker_ros2/camera_driver.h
+++ b/include/flir_spinnaker_ros2/camera_driver.h
@@ -86,6 +86,7 @@ private:
   double exposureTime_;  // in microseconds
   bool autoExposure_;    // if auto exposure is on/off
   bool dumpNodeMap_{false};
+  bool alwaysPublish_{false};
   bool debug_{false};
   bool computeBrightness_{false};
   uint32_t currentExposureTime_{0};

--- a/launch/blackfly_s.launch.py
+++ b/launch/blackfly_s.launch.py
@@ -11,8 +11,10 @@ camera_params = {
     # set parameters defined in grasshopper.cfg    
     'gain_auto': 'Continous',
     'exposure_auto': 'Continuous',
+    'always_publish': True,
     'frame_rate_auto': 'Off',
-    'frame_rate': 100.0,
+    'frame_rate': 20.0,
+    'frame_rate_enable': True,
     'trigger_mode': 'Off',
     'chunk_mode_active': True,
     'chunk_selector_frame_id': 'FrameID',

--- a/src/camera_driver.cpp
+++ b/src/camera_driver.cpp
@@ -166,6 +166,7 @@ void CameraDriver::readParameters()
   LOG_INFO("debug: " << debug_);
   cameraInfoURL_ = this->declare_parameter<std::string>("camerainfo_url", "");
   frameId_ = this->declare_parameter<std::string>("frame_id", get_name());
+  alwaysPublish_ = this->declare_parameter<bool>("always_publish", false);
   dumpNodeMap_ = this->declare_parameter<bool>("dump_node_map", false);
   qosDepth_ = this->declare_parameter<int>("image_queue_size", 4);
   computeBrightness_ =
@@ -435,7 +436,7 @@ void CameraDriver::doPublish(const ImageConstPtr & im)
   const std::string encoding =
     sensor_msgs::image_encodings::BAYER_RGGB8;  // looks good
 
-  if (pub_.getNumSubscribers() > 0) {
+  if (pub_.getNumSubscribers() > 0 || alwaysPublish_) {
     sensor_msgs::msg::CameraInfo::UniquePtr
       cinfo(new sensor_msgs::msg::CameraInfo(cameraInfoMsg_));
     // will make deep copy. Do we need to? Probably...
@@ -452,7 +453,7 @@ void CameraDriver::doPublish(const ImageConstPtr & im)
       publishedCount_++;
     }
   }
-  if (metaPub_->get_subscription_count() != 0) {
+  if (metaPub_->get_subscription_count() != 0 || alwaysPublish_) {
       metaMsg_.header.stamp = t;
       metaMsg_.brightness = im->brightness_;
       metaMsg_.exposure_time = im->exposureTime_;


### PR DESCRIPTION
Add a parameter to always publish output topics. This is both useful for debug and recording bags.