### PR TITLE
Automatic Exposure and Gain Control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,34 @@ install(TARGETS
   DESTINATION lib
 )
 
+ament_auto_add_library(camera_autoexposure SHARED
+  src/camera_autoexposure.cpp
+)
+
+ament_auto_add_executable(camera_autoexposure_node
+  src/camera_autoexposure_node.cpp
+)
+
+rclcpp_components_register_nodes(camera_autoexposure "flir_spinnaker_ros2::CameraAutoExposure")
+
+target_include_directories(camera_autoexposure PRIVATE include)
+
+# the node must go into the project specific lib directory or else
+# the launch file will not find it
+
+install(TARGETS
+  camera_autoexposure_node
+  DESTINATION lib/${PROJECT_NAME}/
+  )
+
+# the shared library goes into the global lib dir so it can
+# be used as a composable node by other projects
+
+install(TARGETS
+  camera_autoexposure
+  DESTINATION lib
+)
+
 install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME}/

--- a/include/flir_spinnaker_ros2/camera_autoexposure.h
+++ b/include/flir_spinnaker_ros2/camera_autoexposure.h
@@ -1,0 +1,82 @@
+// -*-c++-*--------------------------------------------------------------------
+// Copyright 2020 Bernd Pfrommer <bernd.pfrommer@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FLIR_SPINNAKER_ROS2__CAMERA_DRIVER_H_
+#define FLIR_SPINNAKER_ROS2__CAMERA_DRIVER_H_
+
+#include <camera_control_msgs_ros2/msg/camera_control.hpp>
+#include <image_meta_msgs_ros2/msg/image_meta_data.hpp>
+#include <image_transport/image_transport.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <thread>
+
+namespace flir_spinnaker_ros2
+{
+class CameraAutoExposure : public rclcpp::Node
+{
+public:
+  explicit CameraAutoExposure(const rclcpp::NodeOptions & options);
+  ~CameraAutoExposure();
+
+private:
+
+  void run();  // thread
+
+  // void imageCallback(
+  //   const sensor_msgs::msg::Image::ConstSharedPtr msg);
+  void metaCallback(const image_meta_msgs_ros2::msg::ImageMetaData::ConstSharedPtr msg);
+
+  // rcl_interfaces::msg::SetParametersResult parameterChanged(
+  //   const std::vector<rclcpp::Parameter> & params);
+
+  // ----- variables --
+  std::shared_ptr<rclcpp::Node> node_;
+  // rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr
+  //   image_sub_;
+  rclcpp::Subscription<image_meta_msgs_ros2::msg::ImageMetaData>::SharedPtr
+    camera_meta_sub_;
+  rclcpp::Publisher<camera_control_msgs_ros2::msg::CameraControl>::SharedPtr
+    control_pub_;
+
+  bool debug_{false};
+  std::string camera_name_;
+  uint32_t current_exposure_time_{0};
+  float current_gain_{std::numeric_limits<float>::lowest()};
+  int16_t target_intensity_;
+
+  static constexpr uint32_t kMinExposureUs = 1000;
+  static constexpr uint32_t kMaxExposureUs = 30000;
+  static constexpr float    kMaxGain = 40.0;
+  static constexpr uint32_t kExposureTransition = 20000;
+  static constexpr float    kGainTransition = 15.0;
+
+  double intensity_accum_ = 0.0;
+  // Bias on the IIR, range is 0.-1. where 1.0 would immediately replace the accum with the current value (ie no filtering).
+  double intensity_update_gain_ = 1.0;
+
+  // sensor_msgs::msg::Image::ConstSharedPtr imageMsg_;
+  image_meta_msgs_ros2::msg::ImageMetaData::ConstSharedPtr metaMsg_;
+
+  // rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
+  //   callbackHandle_;  
+  bool exposure_running_{false};
+  std::shared_ptr<std::thread> thread_;
+  bool should_run_{true};
+  // std::vector<std::string> parameterList_;  // remember original ordering
+  int qosDepth_{4};
+};
+}  // namespace flir_spinnaker_ros2
+#endif  // FLIR_SPINNAKER_ROS2__CAMERA_DRIVER_H_

--- a/include/flir_spinnaker_ros2/camera_autoexposure.h
+++ b/include/flir_spinnaker_ros2/camera_autoexposure.h
@@ -35,17 +35,10 @@ private:
 
   void run();  // thread
 
-  // void imageCallback(
-  //   const sensor_msgs::msg::Image::ConstSharedPtr msg);
   void metaCallback(const image_meta_msgs_ros2::msg::ImageMetaData::ConstSharedPtr msg);
-
-  // rcl_interfaces::msg::SetParametersResult parameterChanged(
-  //   const std::vector<rclcpp::Parameter> & params);
 
   // ----- variables --
   std::shared_ptr<rclcpp::Node> node_;
-  // rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr
-  //   image_sub_;
   rclcpp::Subscription<image_meta_msgs_ros2::msg::ImageMetaData>::SharedPtr
     camera_meta_sub_;
   rclcpp::Publisher<camera_control_msgs_ros2::msg::CameraControl>::SharedPtr
@@ -67,15 +60,11 @@ private:
   // Bias on the IIR, range is 0.-1. where 1.0 would immediately replace the accum with the current value (ie no filtering).
   double intensity_update_gain_ = 1.0;
 
-  // sensor_msgs::msg::Image::ConstSharedPtr imageMsg_;
   image_meta_msgs_ros2::msg::ImageMetaData::ConstSharedPtr metaMsg_;
 
-  // rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr
-  //   callbackHandle_;  
   bool exposure_running_{false};
   std::shared_ptr<std::thread> thread_;
   bool should_run_{true};
-  // std::vector<std::string> parameterList_;  // remember original ordering
   int qosDepth_{4};
 };
 }  // namespace flir_spinnaker_ros2

--- a/launch/blackfly_s.launch.py
+++ b/launch/blackfly_s.launch.py
@@ -6,11 +6,11 @@ from ament_index_python.packages import get_package_share_directory
 
 camera_params = {
     'debug': False,
-    'compute_brightness': False,
+    'compute_brightness': True,
     'dump_node_map': False,
     # set parameters defined in grasshopper.cfg    
-    'gain_auto': 'Continous',
-    'exposure_auto': 'Continuous',
+    'gain_auto': 'Off',
+    'exposure_auto': 'Off',
     'always_publish': True,
     'frame_rate_auto': 'Off',
     'frame_rate': 20.0,

--- a/launch/blackfly_s_autoexposure.py
+++ b/launch/blackfly_s_autoexposure.py
@@ -1,0 +1,65 @@
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration as LaunchConfig
+from launch.actions import DeclareLaunchArgument as LaunchArg
+from launch import LaunchDescription
+from ament_index_python.packages import get_package_share_directory
+
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+camera_params = {
+    'debug': False,
+    'compute_brightness': True,
+    'dump_node_map': False,
+    # set parameters defined in grasshopper.cfg    
+    'gain_auto': 'Off',
+    'exposure_auto': 'Off',
+    'always_publish': True,
+    'frame_rate_auto': 'Off',
+    'frame_rate': 20.0,
+    'frame_rate_enable': True,
+    'trigger_mode': 'Off',
+    'chunk_mode_active': True,
+    'chunk_selector_frame_id': 'FrameID',
+    'chunk_enable_frame_id': True,
+    'chunk_selector_exposure_time': 'ExposureTime',
+    'chunk_enable_exposure_time': True,
+    'chunk_selector_gain': 'Gain',
+    'chunk_enable_gain': True,
+    'chunk_selector_timestamp': 'Timestamp',
+    'chunk_enable_timestamp': True,
+    }
+
+def generate_launch_description():
+    """Generate launch description with multiple components."""
+    flir_dir = get_package_share_directory('flir_spinnaker_ros2')
+    config_dir = flir_dir + '/config/'
+    name_arg = LaunchArg('camera_name', default_value='blackfly_s',
+                         description='camera name')
+    serial_arg = LaunchArg('serial', default_value="'20435008'",
+                         description='serial number')
+    print([LaunchConfig('serial'),'_'])
+    container = ComposableNodeContainer(
+            name='blackfly_s_container',
+            namespace='',
+            package='rclcpp_components',
+            executable='component_container',
+            composable_node_descriptions=[
+                ComposableNode(
+                        package='flir_spinnaker_ros2',
+                        plugin='flir_spinnaker_ros2::CameraDriver',
+                        name=[LaunchConfig('camera_name')],
+                        parameters=[camera_params,
+                                    {'parameter_file': config_dir + 'blackfly_s.cfg',
+                                    'serial_number': [LaunchConfig('serial')],
+                                    }],
+                        remappings=[('~/control', '/exposure_control/control'), ]),
+                ComposableNode(
+                        package='flir_spinnaker_ros2',
+                        plugin='flir_spinnaker_ros2::CameraAutoExposure',
+                        name=['blackfly_s_autoexposure'])
+            ],
+            output='screen',
+    )
+
+    return LaunchDescription([name_arg, serial_arg, container])

--- a/src/camera_autoexposure.cpp
+++ b/src/camera_autoexposure.cpp
@@ -46,8 +46,6 @@ CameraAutoExposure::CameraAutoExposure(const rclcpp::NodeOptions& options)
   get_parameter("target_intensity", target_intensity_);
   declare_parameter("intensity_update_gain", 0.5);
   get_parameter("intensity_update_gain", intensity_update_gain_);
-  // image_sub_ = create_subscription<sensor_msgs::msg::Image>(
-  //     "/" + camera_name_ + "/image_raw", 1, std::bind(&CameraAutoExposure::imageCallback, this, std::placeholders::_1));
   camera_meta_sub_ = create_subscription<image_meta_msgs_ros2::msg::ImageMetaData>(
       "/" + camera_name_ + "/meta", qosDepth_, std::bind(&CameraAutoExposure::metaCallback, this, std::placeholders::_1));
   control_pub_ = 
@@ -102,12 +100,11 @@ void CameraAutoExposure::metaCallback(
     camera_control_msg.exposure_time = max_exposure_time;
   }
 
-  static int skip_count = 20;
-  if (--skip_count == 0) {
-    RCLCPP_DEBUG_STREAM(get_logger(), "Received message with brightness " << msg->brightness << " exposure " << msg->exposure_time << " gain " << msg->gain << " gives filtered intensity " << filtered_intensity);
-    RCLCPP_DEBUG_STREAM(get_logger(), "Setting exposure to " << camera_control_msg.exposure_time << " gain to " << camera_control_msg.gain);
-    skip_count = 20;
-  }
+  RCLCPP_DEBUG_STREAM(
+    get_logger(), "Computed filtered intensity "
+                    << filtered_intensity << "Setting exposure to "
+                    << camera_control_msg.exposure_time << " gain to "
+                    << camera_control_msg.gain);
   control_pub_->publish(camera_control_msg);
 }
 

--- a/src/camera_autoexposure.cpp
+++ b/src/camera_autoexposure.cpp
@@ -51,7 +51,7 @@ CameraAutoExposure::CameraAutoExposure(const rclcpp::NodeOptions& options)
   camera_meta_sub_ = create_subscription<image_meta_msgs_ros2::msg::ImageMetaData>(
       "/" + camera_name_ + "/meta", qosDepth_, std::bind(&CameraAutoExposure::metaCallback, this, std::placeholders::_1));
   control_pub_ = 
-    create_publisher<camera_control_msgs_ros2::msg::CameraControl>("/exposure_control/control", qosDepth_);
+    create_publisher<camera_control_msgs_ros2::msg::CameraControl>("/" + camera_name_ + "/control", qosDepth_);
 }
 
 CameraAutoExposure::~CameraAutoExposure() {
@@ -104,8 +104,8 @@ void CameraAutoExposure::metaCallback(
 
   static int skip_count = 20;
   if (--skip_count == 0) {
-    RCLCPP_INFO_STREAM(get_logger(), "Received message with brightness " << msg->brightness << " exposure " << msg->exposure_time << " gain " << msg->gain << " gives filtered intensity " << filtered_intensity);
-    RCLCPP_INFO_STREAM(get_logger(), "Setting exposure to " << camera_control_msg.exposure_time << " gain to " << camera_control_msg.gain);
+    RCLCPP_DEBUG_STREAM(get_logger(), "Received message with brightness " << msg->brightness << " exposure " << msg->exposure_time << " gain " << msg->gain << " gives filtered intensity " << filtered_intensity);
+    RCLCPP_DEBUG_STREAM(get_logger(), "Setting exposure to " << camera_control_msg.exposure_time << " gain to " << camera_control_msg.gain);
     skip_count = 20;
   }
   control_pub_->publish(camera_control_msg);

--- a/src/camera_autoexposure.cpp
+++ b/src/camera_autoexposure.cpp
@@ -60,6 +60,7 @@ void CameraAutoExposure::metaCallback(
   const image_meta_msgs_ros2::msg::ImageMetaData::ConstSharedPtr msg) {
   if (msg->brightness == -1) {
     RCLCPP_WARN(get_logger(), "Brightness is disabled, not running exposure control.");
+    return;
   }
 
   // Filter the intensity with a single pole IIR based on the coef configured.

--- a/src/camera_autoexposure.cpp
+++ b/src/camera_autoexposure.cpp
@@ -1,0 +1,120 @@
+// -*-c++-*--------------------------------------------------------------------
+// Copyright 2020 Bernd Pfrommer <bernd.pfrommer@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <flir_spinnaker_ros2/camera_autoexposure.h>
+
+#include <fstream>
+#include <functional>
+#include <image_transport/image_transport.hpp>
+#include <iomanip>
+#include <iostream>
+#include <math.h>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/fill_image.hpp>
+#include <sensor_msgs/image_encodings.hpp>
+
+#include "logging.h"
+
+namespace flir_spinnaker_ros2
+{
+
+constexpr uint32_t CameraAutoExposure::kMinExposureUs;
+constexpr uint32_t CameraAutoExposure::kMaxExposureUs;
+constexpr float CameraAutoExposure::kMaxGain;
+constexpr uint32_t CameraAutoExposure::kExposureTransition;
+constexpr float CameraAutoExposure::kGainTransition;
+
+CameraAutoExposure::CameraAutoExposure(const rclcpp::NodeOptions& options) 
+: Node("cam_autoexposure", options)
+{
+
+  declare_parameter("camera_name", "blackfly_s");
+  get_parameter("camera_name", camera_name_);
+  declare_parameter("target_intensity", 120);
+  get_parameter("target_intensity", target_intensity_);
+  declare_parameter("intensity_update_gain", 0.5);
+  get_parameter("intensity_update_gain", intensity_update_gain_);
+  // image_sub_ = create_subscription<sensor_msgs::msg::Image>(
+  //     "/" + camera_name_ + "/image_raw", 1, std::bind(&CameraAutoExposure::imageCallback, this, std::placeholders::_1));
+  camera_meta_sub_ = create_subscription<image_meta_msgs_ros2::msg::ImageMetaData>(
+      "/" + camera_name_ + "/meta", qosDepth_, std::bind(&CameraAutoExposure::metaCallback, this, std::placeholders::_1));
+  control_pub_ = 
+    create_publisher<camera_control_msgs_ros2::msg::CameraControl>("/exposure_control/control", qosDepth_);
+}
+
+CameraAutoExposure::~CameraAutoExposure() {
+
+}
+
+void CameraAutoExposure::metaCallback(
+  const image_meta_msgs_ros2::msg::ImageMetaData::ConstSharedPtr msg) {
+  if (msg->brightness == -1) {
+    RCLCPP_WARN(get_logger(), "Brightness is disabled, not running exposure control.");
+  }
+
+  // Filter the intensity with a single pole IIR based on the coef configured.
+  const int16_t new_intensity = msg->brightness;
+  const double filtered_intensity = ((1.0-intensity_update_gain_)*intensity_accum_) + (intensity_update_gain_ * new_intensity);
+  intensity_accum_ = filtered_intensity;
+
+  const uint32_t current_exposure_us = msg->exposure_time;
+  const double combined_exposure_gain = current_exposure_us * std::pow(10, msg->gain / 20.0);
+
+  // Compute the multiplier to apply to the current exposure time that would result in the desired intensity.
+  const double target_exposure_gain_multiplier = target_intensity_ / filtered_intensity;
+
+  const double target_combined_exposure_gain = combined_exposure_gain * target_exposure_gain_multiplier;
+
+  camera_control_msgs_ros2::msg::CameraControl camera_control_msg;
+  camera_control_msg.header.stamp = now();
+  camera_control_msg.header.frame_id = msg->header.frame_id;
+
+  const uint32_t max_exposure_time = std::min(msg->max_exposure_time, kMaxExposureUs);
+  if (target_combined_exposure_gain < kExposureTransition) {
+    camera_control_msg.exposure_time = target_combined_exposure_gain;
+    camera_control_msg.gain = 1.0;
+  } else if (target_combined_exposure_gain < (kExposureTransition * std::pow(10, kGainTransition / 20.0))) {
+    camera_control_msg.exposure_time = kExposureTransition;
+    const double target_linear_gain = target_combined_exposure_gain / kExposureTransition;
+    camera_control_msg.gain = 20 * std::log10(target_linear_gain);
+  } else if (target_combined_exposure_gain < (max_exposure_time * std::pow(10, kGainTransition / 20.0))) {
+    camera_control_msg.gain = kGainTransition;
+    const double target_exposure = target_combined_exposure_gain / std::pow(10, kGainTransition / 20.0);
+    camera_control_msg.exposure_time = static_cast<uint32_t>(std::round(target_exposure));
+  } else if (target_combined_exposure_gain < (max_exposure_time * std::pow(10, kMaxGain / 20.0))) {
+    camera_control_msg.exposure_time = max_exposure_time;
+    const double target_linear_gain = target_combined_exposure_gain / max_exposure_time;
+    camera_control_msg.gain = 20 * std::log10(target_linear_gain);
+  } else {
+    camera_control_msg.gain = kMaxGain;
+    camera_control_msg.exposure_time = max_exposure_time;
+  }
+
+  static int skip_count = 20;
+  if (--skip_count == 0) {
+    RCLCPP_INFO_STREAM(get_logger(), "Received message with brightness " << msg->brightness << " exposure " << msg->exposure_time << " gain " << msg->gain << " gives filtered intensity " << filtered_intensity);
+    RCLCPP_INFO_STREAM(get_logger(), "Setting exposure to " << camera_control_msg.exposure_time << " gain to " << camera_control_msg.gain);
+    skip_count = 20;
+  }
+  control_pub_->publish(camera_control_msg);
+}
+
+void CameraAutoExposure::run() {
+
+}
+
+}  // namespace flir_spinnaker_ros2
+
+RCLCPP_COMPONENTS_REGISTER_NODE(flir_spinnaker_ros2::CameraAutoExposure)

--- a/src/camera_autoexposure_node.cpp
+++ b/src/camera_autoexposure_node.cpp
@@ -1,0 +1,32 @@
+// -*-c++-*--------------------------------------------------------------------
+// Copyright 2020 Bernd Pfrommer <bernd.pfrommer@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <flir_spinnaker_ros2/camera_autoexposure.h>
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node =
+    std::make_shared<flir_spinnaker_ros2::CameraAutoExposure>(rclcpp::NodeOptions());
+
+  RCLCPP_INFO(node->get_logger(), "camera_autoexposure_node started up!");
+  // actually run the node
+  rclcpp::spin(node);  // should not return
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/camera_driver.cpp
+++ b/src/camera_driver.cpp
@@ -230,7 +230,7 @@ void CameraDriver::createCameraParameters()
 
 bool CameraDriver::setEnum(const std::string & nodeName, const std::string & v)
 {
-  LOG_INFO("setting " << nodeName << " to: " << v);
+  LOG_DEBUG("setting " << nodeName << " to: " << v);
   std::string retV;  // what actually was set
   std::string msg = driver_->setEnum(nodeName, v, &retV);
   bool status(true);
@@ -247,7 +247,7 @@ bool CameraDriver::setEnum(const std::string & nodeName, const std::string & v)
 
 bool CameraDriver::setDouble(const std::string & nodeName, double v)
 {
-  LOG_INFO("setting " << nodeName << " to: " << v);
+  LOG_DEBUG("setting " << nodeName << " to: " << v);
   double retV;  // what actually was set
   std::string msg = driver_->setDouble(nodeName, v, &retV);
   bool status(true);
@@ -264,7 +264,7 @@ bool CameraDriver::setDouble(const std::string & nodeName, double v)
 
 bool CameraDriver::setBool(const std::string & nodeName, bool v)
 {
-  LOG_INFO("setting " << nodeName << " to: " << v);
+  LOG_DEBUG("setting " << nodeName << " to: " << v);
   bool retV;  // what actually was set
   std::string msg = driver_->setBool(nodeName, v, &retV);
   bool status(true);

--- a/src/camera_driver.cpp
+++ b/src/camera_driver.cpp
@@ -345,11 +345,9 @@ rcl_interfaces::msg::SetParametersResult CameraDriver::parameterChanged(
 void CameraDriver::controlCallback(
   const camera_control_msgs_ros2::msg::CameraControl::UniquePtr msg)
 {
-  /*
-  LOG_INFO(
-    "control msg: time: " << currentExposureTime_ << " -> "
+  LOG_DEBUG("control msg: time: " << currentExposureTime_ << " -> "
                           << msg->exposure_time << " gain: " << currentGain_
-                          << " -> " << msg->gain); */
+                          << " -> " << msg->gain); 
   const uint32_t et = msg->exposure_time;
   const float gain = msg->gain;
   bool logTime(false);
@@ -382,10 +380,10 @@ void CameraDriver::controlCallback(
   }
 
   if (logTime) {
-    LOG_INFO("changed exposure time to " << et << "us");
+    LOG_DEBUG("changed exposure time to " << et << "us");
   }
   if (logGain) {
-    LOG_INFO("changed gain to " << gain << "db");
+    LOG_DEBUG("changed gain to " << gain << "db");
   }
 }
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -26,6 +26,10 @@ namespace flir_spinnaker_ros2
     SS << __VA_ARGS__;                   \
     throw(std::runtime_error(SS.str())); \
   }
+#define LOG_DEBUG(...)                              \
+  {                                                \
+    RCLCPP_DEBUG_STREAM(get_logger(), __VA_ARGS__); \
+  }
 #define LOG_INFO(...)                              \
   {                                                \
     RCLCPP_INFO_STREAM(get_logger(), __VA_ARGS__); \


### PR DESCRIPTION
Multi-tier exposure/gain control algorithm. Each band is configured as a range, where either exposure or gain is locked in that range and the other is controlling the output intensity.
Range 0: Gain: 0dB (locked) Exposure: <20ms
Range 1: Gain: <15dB. Exposure 20ms (locked)
Range 2: Gain: 15dB (locked). Exposure: <33ms
Range4: Gain: <40dB. Exposure: 33ms (locked). 